### PR TITLE
fix GAPDH equations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Glycolysis"
 uuid = "1acb6d80-f93a-4117-912f-ae4c0dd090a6"
 authors = ["Denis-Titov <titov@berkeley.edu> and contributors"]
-version = "0.7.1"
+version = "0.7.2"
 
 [deps]
 LabelledArrays = "2ee39098-c373-598a-b85f-a56591580800"

--- a/src/13C_tracing_enzyme_rates.jl
+++ b/src/13C_tracing_enzyme_rates.jl
@@ -233,7 +233,7 @@ function rate_isotope_tracing_GAPDH(metabs, params, isotope::Symbol)
         metabs.NADH / params.GAPDH_K_i_NADH * (
             1 +
             GAP / params.GAPDH_K_GAP * (1 + metabs.Phosphate / params.GAPDH_K_i_Phosphate) +
-            BPG / (params.GAPDH_α_i_BPG * params.GAPDH_K_BPG)
+            BPG / (params.GAPDH_β_i_BPG * params.GAPDH_K_BPG)
         )
     if isotope == :C12
         Rate = ((

--- a/src/enzyme_binding.jl
+++ b/src/enzyme_binding.jl
@@ -265,7 +265,7 @@ function binding_GAPDH(metabs, params)
         metabs.NADH / params.GAPDH_K_i_NADH * (
             1 +
             metabs.GAP / params.GAPDH_K_GAP * (1 + metabs.Phosphate / params.GAPDH_K_i_Phosphate) +
-            metabs.BPG / (params.GAPDH_α_i_BPG * params.GAPDH_K_BPG)
+            metabs.BPG / (params.GAPDH_β_i_BPG * params.GAPDH_K_BPG)
         )
     Z = (Z_a^4 + params.GAPDH_L * Z_i^4)
     GAP_bound =
@@ -326,7 +326,7 @@ function binding_GAPDH(metabs, params)
                 (
                     1 +
                     metabs.NAD / params.GAPDH_K_i_NAD +
-                    metabs.NADH / (params.GAPDH_α_i_BPG * params.GAPDH_K_i_NADH)
+                    metabs.NADH / (params.GAPDH_β_i_BPG * params.GAPDH_K_i_NADH)
                 ) *
                 (1 + metabs.Phosphate / params.GAPDH_K_i_Phosphate) *
                 Z_i^3
@@ -347,7 +347,7 @@ function binding_GAPDH(metabs, params)
                 (
                     1 +
                     metabs.GAP / params.GAPDH_K_GAP * (1 + metabs.Phosphate / params.GAPDH_K_i_Phosphate) +
-                    metabs.BPG / (params.GAPDH_α_i_BPG * params.GAPDH_K_BPG)
+                    metabs.BPG / (params.GAPDH_β_i_BPG * params.GAPDH_K_BPG)
                 ) *
                 Z_i^3
             )


### PR DESCRIPTION
replace alpha with beta in GAPDH binidng and tracing equation to make it consistent with previously update GAPDH rate equations